### PR TITLE
Fix ctable array and legacy tl_module_comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+## [1.23.3] - 2020-12-16
+- fixed non-existent service exception for comment type in reader config element
+- fixed ctable definition in tl_reader_config was not an array
+
 ## [1.23.2] - 2020-10-30
 - fixed non-existent service exception in list config element (#4)
 

--- a/src/DataContainer/ReaderConfigElementContainer.php
+++ b/src/DataContainer/ReaderConfigElementContainer.php
@@ -8,6 +8,7 @@
 
 namespace HeimrichHannot\ReaderBundle\DataContainer;
 
+use Contao\Controller;
 use Contao\StringUtil;
 use HeimrichHannot\ConfigElementTypeBundle\ConfigElementType\ConfigElementTypeInterface;
 use HeimrichHannot\ReaderBundle\ConfigElementType\RelatedConfigElementType;
@@ -144,5 +145,15 @@ class ReaderConfigElementContainer
         return '<div class="tl_content_left">'.($rows['title'] ?: $rows['id']).' <span style="color:#b3b3b3; padding-left:3px">['
             .$reference[$rows['type']].'] ('
             .\Date::parse(\Contao\Config::get('datimFormat'), trim($rows['dateAdded'])).')</span></div>';
+    }
+
+    /**
+     * Return all template files of a particular group as array.
+     *
+     * @return array An array of template names
+     */
+    public function getCommentTemplates()
+    {
+        return Controller::getTemplateGroup('com_');
     }
 }

--- a/src/Resources/contao/dca/tl_reader_config.php
+++ b/src/Resources/contao/dca/tl_reader_config.php
@@ -12,7 +12,7 @@
 $GLOBALS['TL_DCA']['tl_reader_config'] = [
     'config' => [
         'dataContainer' => 'Table',
-        'ctable' => 'tl_reader_config_element',
+        'ctable' => ['tl_reader_config_element'],
         'enableVersioning' => true,
         'onload_callback' => [
             ['huh.reader.backend.reader-config', 'modifyPalette'],
@@ -282,7 +282,7 @@ $GLOBALS['TL_DCA']['tl_reader_config'] = [
             'exclude' => true,
             'filter' => true,
             'inputType' => 'select',
-            'options_callback' => function (\Contao\DataContainer $dc) {
+            'options_callback' => function (Contao\DataContainer $dc) {
                 return $dc->activeRecord->id > 0 ? System::getContainer()->get('huh.reader.util.reader-config-util')->getFields($dc->activeRecord->id) : [];
             },
             'eval' => ['chosen' => true, 'includeBlankOption' => true, 'tl_class' => 'w50', 'mandatory' => true],
@@ -293,7 +293,7 @@ $GLOBALS['TL_DCA']['tl_reader_config'] = [
             'exclude' => true,
             'filter' => true,
             'inputType' => 'select',
-            'options_callback' => function (\Contao\DataContainer $dc) {
+            'options_callback' => function (Contao\DataContainer $dc) {
                 return $dc->activeRecord->id > 0 ? System::getContainer()->get('huh.reader.util.reader-config-util')->getFields($dc->activeRecord->id) : [];
             },
             'eval' => ['chosen' => true, 'includeBlankOption' => true, 'tl_class' => 'w50', 'mandatory' => true],
@@ -394,7 +394,7 @@ $GLOBALS['TL_DCA']['tl_reader_config'] = [
             'label' => &$GLOBALS['TL_LANG']['tl_reader_config']['jumpToOverviewLabel'],
             'exclude' => true,
             'inputType' => 'select',
-            'options_callback' => function (\DataContainer $dc) {
+            'options_callback' => function (DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.utils.choice.message')->getCachedChoices('huh.reader.label.overview');
             },
             'eval' => ['chosen' => true, 'mandatory' => true, 'maxlength' => 128, 'includeBlankOption' => true, 'tl_class' => 'w50'],

--- a/src/Resources/contao/dca/tl_reader_config_element.php
+++ b/src/Resources/contao/dca/tl_reader_config_element.php
@@ -568,7 +568,7 @@ $GLOBALS['TL_DCA']['tl_reader_config_element'] = [
             'exclude' => true,
             'inputType' => 'select',
             'default' => 'readernavigation_default',
-            'options_callback' => function (\Contao\DataContainer $dc) {
+            'options_callback' => function (Contao\DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.utils.choice.twig_template')->getCachedChoices(['readernavigation_']);
             },
             'eval' => ['tl_class' => 'w50', 'includeBlankOption' => true, 'mandatory' => true],
@@ -589,7 +589,7 @@ $GLOBALS['TL_DCA']['tl_reader_config_element'] = [
             'exclude' => true,
             'inputType' => 'select',
             'default' => 'huh.reader.element.label.previous.default',
-            'options_callback' => function (\DataContainer $dc) {
+            'options_callback' => function (DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.utils.choice.message')->getCachedChoices('huh.reader.element.label.previous');
             },
             'eval' => ['chosen' => true, 'mandatory' => true, 'maxlength' => 128, 'includeBlankOption' => true, 'tl_class' => 'w50'],
@@ -600,7 +600,7 @@ $GLOBALS['TL_DCA']['tl_reader_config_element'] = [
             'exclude' => true,
             'inputType' => 'select',
             'default' => 'huh.reader.element.label.next.default',
-            'options_callback' => function (\DataContainer $dc) {
+            'options_callback' => function (DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.utils.choice.message')->getCachedChoices('huh.reader.element.label.next');
             },
             'eval' => ['chosen' => true, 'mandatory' => true, 'maxlength' => 128, 'includeBlankOption' => true, 'tl_class' => 'w50'],
@@ -611,7 +611,7 @@ $GLOBALS['TL_DCA']['tl_reader_config_element'] = [
             'exclude' => true,
             'inputType' => 'select',
             'default' => 'huh.reader.element.title.previous.default',
-            'options_callback' => function (\DataContainer $dc) {
+            'options_callback' => function (DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.utils.choice.message')->getCachedChoices('huh.reader.element.title.previous');
             },
             'eval' => ['chosen' => true, 'maxlength' => 128, 'includeBlankOption' => true, 'tl_class' => 'w50'],
@@ -622,7 +622,7 @@ $GLOBALS['TL_DCA']['tl_reader_config_element'] = [
             'exclude' => true,
             'inputType' => 'select',
             'default' => 'huh.reader.element.title.next.default',
-            'options_callback' => function (\DataContainer $dc) {
+            'options_callback' => function (DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.utils.choice.message')->getCachedChoices('huh.reader.element.title.next');
             },
             'eval' => ['chosen' => true, 'maxlength' => 128, 'includeBlankOption' => true, 'tl_class' => 'w50'],
@@ -654,7 +654,7 @@ $GLOBALS['TL_DCA']['tl_reader_config_element'] = [
             'exclude' => true,
             'inputType' => 'select',
             'default' => 'readersyndication_default',
-            'options_callback' => function (\Contao\DataContainer $dc) {
+            'options_callback' => function (Contao\DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.utils.choice.twig_template')->getCachedChoices(['readersyndication_']);
             },
             'eval' => ['tl_class' => 'w50', 'includeBlankOption' => true, 'mandatory' => true],
@@ -707,7 +707,7 @@ $GLOBALS['TL_DCA']['tl_reader_config_element'] = [
             'exclude' => true,
             'inputType' => 'select',
             'default' => 'huh.reader.element.mail.subject.syndication.default',
-            'options_callback' => function (\DataContainer $dc) {
+            'options_callback' => function (DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.utils.choice.message')->getCachedChoices('huh.reader.element.mail.subject');
             },
             'eval' => ['chosen' => true, 'mandatory' => true, 'maxlength' => 128, 'includeBlankOption' => true, 'tl_class' => 'w50'],
@@ -718,7 +718,7 @@ $GLOBALS['TL_DCA']['tl_reader_config_element'] = [
             'exclude' => true,
             'inputType' => 'select',
             'default' => 'huh.reader.element.mail.body.syndication.default',
-            'options_callback' => function (\DataContainer $dc) {
+            'options_callback' => function (DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.utils.choice.message')->getCachedChoices('huh.reader.element.mail.body');
             },
             'eval' => ['chosen' => true, 'mandatory' => true, 'maxlength' => 128, 'includeBlankOption' => true, 'tl_class' => 'w50'],
@@ -744,7 +744,7 @@ $GLOBALS['TL_DCA']['tl_reader_config_element'] = [
             'exclude' => true,
             'inputType' => 'select',
             'default' => 'huh.reader.element.feedback.subject.syndication.default',
-            'options_callback' => function (\DataContainer $dc) {
+            'options_callback' => function (DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.utils.choice.message')->getCachedChoices('huh.reader.element.feedback.subject');
             },
             'eval' => ['chosen' => true, 'mandatory' => true, 'maxlength' => 128, 'includeBlankOption' => true, 'tl_class' => 'w50'],
@@ -755,7 +755,7 @@ $GLOBALS['TL_DCA']['tl_reader_config_element'] = [
             'exclude' => true,
             'inputType' => 'select',
             'default' => 'huh.reader.element.feedback.body.syndication.default',
-            'options_callback' => function (\DataContainer $dc) {
+            'options_callback' => function (DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.utils.choice.message')->getCachedChoices('huh.reader.element.feedback.body');
             },
             'eval' => ['chosen' => true, 'mandatory' => true, 'maxlength' => 128, 'includeBlankOption' => true, 'tl_class' => 'w50'],
@@ -773,7 +773,7 @@ $GLOBALS['TL_DCA']['tl_reader_config_element'] = [
             'exclude' => true,
             'inputType' => 'select',
             'default' => 'default',
-            'options_callback' => function (\Contao\DataContainer $dc) {
+            'options_callback' => function (Contao\DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.reader.choice.syndication-pdf-reader')->getCachedChoices();
             },
             'eval' => ['tl_class' => 'w50', 'includeBlankOption' => true, 'mandatory' => true],
@@ -791,7 +791,7 @@ $GLOBALS['TL_DCA']['tl_reader_config_element'] = [
             'exclude' => true,
             'inputType' => 'select',
             'default' => 'readerpdf_default',
-            'options_callback' => function (\Contao\DataContainer $dc) {
+            'options_callback' => function (Contao\DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.utils.choice.twig_template')->getCachedChoices(['readerpdf_']);
             },
             'eval' => ['tl_class' => 'w50', 'includeBlankOption' => true, 'mandatory' => true],
@@ -838,7 +838,7 @@ $GLOBALS['TL_DCA']['tl_reader_config_element'] = [
             'exclude' => true,
             'inputType' => 'select',
             'default' => 'readerprint_default',
-            'options_callback' => function (\Contao\DataContainer $dc) {
+            'options_callback' => function (Contao\DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.utils.choice.twig_template')->getCachedChoices(['readerprint_']);
             },
             'eval' => ['tl_class' => 'w50', 'includeBlankOption' => true, 'mandatory' => true],
@@ -931,7 +931,7 @@ $GLOBALS['TL_DCA']['tl_reader_config_element'] = [
             'label' => &$GLOBALS['TL_LANG']['tl_reader_config_element']['commentTemplate'],
             'exclude' => true,
             'inputType' => 'select',
-            'options_callback' => ['tl_module_comments', 'getCommentTemplates'],
+            'options_callback' => [\HeimrichHannot\ReaderBundle\DataContainer\ReaderConfigElementContainer::class, 'getCommentTemplates'],
             'eval' => ['tl_class' => 'w50', 'includeBlankOption' => true],
             'sql' => "varchar(64) NOT NULL default ''",
         ],
@@ -1197,7 +1197,7 @@ if (\Contao\System::getContainer()->get('huh.utils.container')->isBundleActive('
             'exclude' => true,
             'filter' => true,
             'inputType' => 'select',
-            'options_callback' => function (\Contao\DataContainer $dc) {
+            'options_callback' => function (Contao\DataContainer $dc) {
                 return System::getContainer()->get('huh.utils.choice.model_instance')->getCachedChoices([
                     'dataContainer' => 'tl_module',
                     'labelPattern' => '%name% (ID %id%)',
@@ -1250,7 +1250,7 @@ if (\Contao\System::getContainer()->get('huh.utils.container')->isBundleActive('
             'exclude' => true,
             'inputType' => 'select',
             'default' => 'config_element_tags_default.html',
-            'options_callback' => function (\Contao\DataContainer $dc) {
+            'options_callback' => function (Contao\DataContainer $dc) {
                 return \Contao\System::getContainer()->get('huh.utils.choice.twig_template')->getCachedChoices(['config_element_tags_']);
             },
             'eval' => ['tl_class' => 'w50', 'includeBlankOption' => true, 'mandatory' => true],
@@ -1268,7 +1268,7 @@ if (\Contao\System::getContainer()->get('huh.utils.container')->isBundleActive('
             'exclude' => true,
             'filter' => true,
             'inputType' => 'select',
-            'options_callback' => function (\Contao\DataContainer $dc) {
+            'options_callback' => function (Contao\DataContainer $dc) {
                 return System::getContainer()->get('huh.utils.choice.model_instance')->getCachedChoices([
                     'dataContainer' => 'tl_filter_config',
                     'labelPattern' => '%title% (ID %id%)',
@@ -1282,7 +1282,7 @@ if (\Contao\System::getContainer()->get('huh.utils.container')->isBundleActive('
             'exclude' => true,
             'filter' => true,
             'inputType' => 'select',
-            'options_callback' => function (\Contao\DataContainer $dc) {
+            'options_callback' => function (Contao\DataContainer $dc) {
                 if (!$dc->activeRecord->tagsFilter) {
                     return [];
                 }


### PR DESCRIPTION
Folgende Behebungen:
- ctable muss ein Array sein
- 'tl_module_comments' existiert nicht und wurde ersetzt
- php-cs-fixer